### PR TITLE
Remove obsolete AY8912 project references

### DIFF
--- a/CSpectPlugins/CSpectPlugins.sln
+++ b/CSpectPlugins/CSpectPlugins.sln
@@ -21,8 +21,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Profiler", "..\Profiler\Pro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileAssociate", "..\FileAssociate\FileAssociate.csproj", "{7FBC889D-403D-4477-998B-A1E51455D6DE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ay8912", "..\ay8912\ay8912.csproj", "{C352CBBD-3F14-4645-A464-B35B5E3A2F37}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/CSpectPlugins/CSpectPlugins/CSpectPlugins.vcxproj
+++ b/CSpectPlugins/CSpectPlugins/CSpectPlugins.vcxproj
@@ -115,9 +115,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\ay8912\ay8912.csproj">
-      <Project>{c352cbbd-3f14-4645-a464-b35b5e3a2f37}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\..\CopperDissassembler\CopperDissassembler.csproj">
       <Project>{93d54582-277e-4aca-a6ab-9cadf5ba1886}</Project>
     </ProjectReference>


### PR DESCRIPTION
Remove obsolete AY8912 project references because solution fails to build in CI pipeline